### PR TITLE
[#2] Added a rule file and type info for boost::any_cast (4-2-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,14 @@ install(FILES ${CMAKE_SOURCE_DIR}/packaging/run_update_collection_mtime_test.py
         DESTINATION ${IRODS_HOME_DIRECTORY}/scripts
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
+install(FILES ${CMAKE_SOURCE_DIR}/packaging/update_collection_mtime.re.template
+        DESTINATION /etc/irods
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+install(FILES ${CMAKE_SOURCE_DIR}/packaging/update_collection_mtime.py.template
+        DESTINATION /etc/irods
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
 set(PLUGIN_PACKAGE_NAME irods-rule-engine-plugin-update-collection-mtime)
 
 set(IRODS_PLUGIN_VERSION_MAJOR ${PLUGIN_VERSION_MAJOR})

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin brings iRODS closer to POSIX semantics by enabling iRODS to automati
 collections when changes are detected within them.
 
 ## Requirements
-- iRODS v4.2.5
+- iRODS v4.2.5+
 - irods-externals-boost package
 - irods-dev package
 - irods-runtime package
@@ -44,7 +44,7 @@ To enable, prepend the following plugin config to the list of rule engines in `/
 The plugin config must be placed at the beginning of the `"rule_engines"` section. Placing the plugin after other 
 plugins could result in mtimes not being updated.
 
-Even though this plugin will process PEPs first due to it's positioning, subsequent Rule Engine Plugins will 
+Even though this plugin will process PEPs first due to it's positioning, subsequent Rule Engine Plugins (REP) will 
 still be allowed to process the same PEPs without any issues.
 ```javascript
 "rule_engines": [
@@ -57,3 +57,36 @@ still be allowed to process the same PEPs without any issues.
     // ... Previously installed rule engine plugin configs ...
 ]
 ```
+
+Because iRODS v4.2.5+ allows multiple REPs to process the same PEPs, it is likely that errors will appear in the
+log file and on the client-side. These errors occur because the PEPs that trigger continuation in the Rule Engine
+Plugin Framework aren't properly handled by a later REP.
+
+To fix this, two rulebase templates are provided:
+- `/etc/irods/update_collection_mtime.re.template` - For users of the Native REP
+- `/etc/irods/update_collection_mtime.py.template` - For users of the Python REP
+
+### How to use the Templates
+#### Native Rule Engine Plugin
+If you are using the Native REP, do the following:
+1. Copy `update_collection_mtime.re.template` and remove the **.template** extension.
+2. Add a new entry to the `re_rulebase_set` list of the Native REP as shown below.
+```javascript
+"rule_engines": [
+    // ... Previously installed rule engine plugin configs (including the MTime REP) ...
+
+    {
+        "instance_name": "irods_rule_engine_plugin-irods_rule_language-instance",
+        "plugin_name": "irods_rule_engine_plugin-irods_rule_language",
+        "plugin_specific_configuration": {
+            "re_rulebase_set": [
+                "core",
+                "update_collection_mtime"
+            ]
+        }
+    }
+]
+```
+
+#### Python Rule Engine Plugin
+Append the contents of `update_collection_mtime.py.template` to `/etc/irods/core.py`.

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -5,11 +5,14 @@ else
   IRODS_SERVICE_GROUP_NAME=`stat --format "%G" /var/lib/irods`
 fi
 
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /etc/irods
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /etc/irods/update_collection_mtime.re.template
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /etc/irods/update_collection_mtime.py.template
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-update_collection_mtime.so
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods/test
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods/test/test_rule_engine_plugin_update_collection_mtime.py
-chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /usr/lib/irods/plugins/rule_engines/libirods_rule_engine_plugin-update_collection_mtime.so
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/run_update_collection_mtime_test.py
 

--- a/packaging/test_rule_engine_plugin_update_collection_mtime.py
+++ b/packaging/test_rule_engine_plugin_update_collection_mtime.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import sys
+import shutil
 
 from time import sleep
 
@@ -13,6 +14,7 @@ else:
 from . import session
 from .. import test
 from .. import lib
+from .. import paths
 from ..configuration import IrodsConfig
 
 class Test_Rule_Engine_Plugin_Update_Collection_MTime(session.make_sessions_mixin([('otherrods', 'rods')], []), unittest.TestCase):
@@ -29,16 +31,39 @@ class Test_Rule_Engine_Plugin_Update_Collection_MTime(session.make_sessions_mixi
 	config = IrodsConfig()
 
         with lib.file_backed_up(config.server_config_path):
-            # Enable the MTime REP (make it the first REP in the list).
-            config.server_config['plugin_configuration']['rule_engines'].insert(0, {
-                'instance_name': 'irods_rule_engine_plugin-update_collection_mtime-instance',
-                'plugin_name': 'irods_rule_engine_plugin-update_collection_mtime',
-                'plugin_specific_configuration': {}
-            })
-            lib.update_json_file_from_dict(config.server_config_path, config.server_config)
-
+            self.enable_mtime_rep(config)
             self.run_collection_pep_tests()
             self.run_data_object_pep_tests()
+            self.run_irule_tests(config.server_config['plugin_configuration']['rule_engines'])
+            self.cleanup()
+
+    def enable_mtime_rep(self, config):
+        # Add the MTime REP to the beginning of the rule engines list.
+        config.server_config['plugin_configuration']['rule_engines'].insert(0, {
+            'instance_name': 'irods_rule_engine_plugin-update_collection_mtime-instance',
+            'plugin_name': 'irods_rule_engine_plugin-update_collection_mtime',
+            'plugin_specific_configuration': {}
+        })
+
+        native_rep = 'irods_rule_engine_plugin-irods_rule_language'
+
+        # Iterate over the rule engines until we find the NREP.
+        # Once the NREP is found, create a copy of the rulebase template (without the ".template"
+        # extension) and add it to the rulebase set of the NREP.
+        for re in config.server_config['plugin_configuration']['rule_engines']:
+            if re['plugin_name'] == native_rep:
+                # Add the NREP rulebase template to the "re_rulebase_set" list.
+                rulebase = os.path.join(paths.config_directory(), 'update_collection_mtime')
+                shutil.copyfile(rulebase + '.re.template', rulebase + '.re')
+                re['plugin_specific_configuration']['re_rulebase_set'] = ['core', 'update_collection_mtime']
+                break
+
+        # Save the changes.
+        lib.update_json_file_from_dict(config.server_config_path, config.server_config)
+
+    def cleanup(self):
+        rulebase = os.path.join(paths.config_directory(), 'update_collection_mtime')
+        os.remove(rulebase + '.re')
 
     def run_collection_pep_tests(self):
         collection = 'rep_mtime_col.d'
@@ -53,6 +78,17 @@ class Test_Rule_Engine_Plugin_Update_Collection_MTime(session.make_sessions_mixi
         self.run_put_data_object_test(filename)
         self.run_rename_data_object_test(filename, new_filename)
         self.run_remove_data_object_test(new_filename)
+
+    def run_irule_tests(self, rule_engines):
+        native_rep = 'irods_rule_engine_plugin-irods_rule_language'
+
+        # Run this test only if the NREP is configured.
+        for re in rule_engines:
+            if re['plugin_name'] == native_rep:
+                msg = 'THIS SHOULD NOT PRODUCE AN ERROR!'
+                cmd = 'irule -r {0}-instance \'writeLine("stdout", "{1}")\' null ruleExecOut'.format(native_rep, msg)
+                self.admin.assert_icommand(cmd, 'STDOUT', msg)
+                break
 
     def run_create_collection_test(self, collection):
         self.run_test(lambda: self.admin.run_icommand('imkdir {0}'.format(collection)))

--- a/packaging/update_collection_mtime.py.template
+++ b/packaging/update_collection_mtime.py.template
@@ -1,0 +1,36 @@
+# This template defines all PEPs handled by the MTime REP that trigger continuation in the
+# Rule Engine Plugin Framework. This file is provided to keep errors from being generated
+# when using the MTime REP.
+#
+# If your iRODS deployment defines these PEPs already, then usage of this rulebase
+# is not needed.
+#
+# To use, copy the contents of this template into "/etc/irods/core.py".
+#
+# For more information about this file, see the "Configuration" section of
+# the README located at the following:
+#
+#     https://github.com/irods/irods_rule_engine_plugin_update_collection_mtime
+#
+
+def pep_api_coll_create_post(rule_args, callback, rei):
+    pass
+
+def pep_api_data_obj_close_post(rule_args, callback, rei):
+    pass
+
+def pep_api_data_obj_close_pre(rule_args, callback, rei):
+    pass
+
+def pep_api_data_obj_put_post(rule_args, callback, rei):
+    pass
+
+def pep_api_data_obj_rename_post(rule_args, callback, rei):
+    pass
+
+def pep_api_data_obj_unlink_post(rule_args, callback, rei):
+    pass
+
+def pep_api_rm_coll_post(rule_args, callback, rei):
+    pass
+

--- a/packaging/update_collection_mtime.re.template
+++ b/packaging/update_collection_mtime.re.template
@@ -1,0 +1,25 @@
+# This template defines all PEPs handled by the MTime REP that trigger continuation in the
+# Rule Engine Plugin Framework. This file is provided to keep errors from being generated
+# when using the MTime REP.
+#
+# If your iRODS deployment defines these PEPs already, then usage of this rulebase
+# is not needed.
+#
+# To use:
+#     1. Copy this template and remove the ".template" extension.
+#     2. Add the new rulebase file to the Native REP's "re_rulebase_set" list.
+#
+# For more information about this file, see the "Configuration" section of
+# the README located at the following:
+#
+#     https://github.com/irods/irods_rule_engine_plugin_update_collection_mtime
+#
+
+pep_api_coll_create_post(*INSTANCE_NAME, *COMM, *INPUT) {}
+pep_api_data_obj_close_post(*INSTANCE_NAME, *COMM, *INPUT) {}
+pep_api_data_obj_close_pre(*INSTANCE_NAME, *COMM, *INPUT) {}
+pep_api_data_obj_put_post(*INSTANCE_NAME, *COMM, *INPUT, *BYTESBUF_INPUT, *OUTPUT) {}
+pep_api_data_obj_rename_post(*INSTANCE_NAME, *COMM, *INPUT) {}
+pep_api_data_obj_unlink_post(*INSTANCE_NAME, *COMM, *INPUT) {}
+pep_api_rm_coll_post(*INSTANCE_NAME, *COMM, *INPUT, *OPR_STAT) {}
+

--- a/src/libirods_rule_engine_plugin-update_collection_mtime.cpp
+++ b/src/libirods_rule_engine_plugin-update_collection_mtime.cpp
@@ -438,19 +438,19 @@ pluggable_rule_engine* plugin_factory(const std::string& _instance_name,
                                       const std::string& _context)
 {
     // clang-format off
-    const auto no_op         = [] { return SUCCESS(); };
-    const auto not_supported = [] { return ERROR(SYS_NOT_SUPPORTED, "not supported"); };
+    const auto no_op         = [](auto...) { return SUCCESS(); };
+    const auto not_supported = [](auto...) { return ERROR(SYS_NOT_SUPPORTED, "not supported"); };
     // clang-format on
 
     auto* re = new pluggable_rule_engine{_instance_name, _context};
 
-    re->add_operation("start", {no_op});
-    re->add_operation("stop", {no_op});
+    re->add_operation("start", operation<const std::string&>{no_op});
+    re->add_operation("stop", operation<const std::string&>{no_op});
     re->add_operation("rule_exists", operation<const std::string&, bool&>{rule_exists});
     re->add_operation("list_rules", operation<std::vector<std::string>&>{list_rules});
     re->add_operation("exec_rule", operation<const std::string&, std::list<boost::any>&, irods::callback>{exec_rule});
-    re->add_operation("exec_rule_text", {not_supported});
-    re->add_operation("exec_rule_expression", {not_supported});
+    re->add_operation("exec_rule_text", operation<const std::string&, msParamArray_t*, const std::string&, irods::callback>{not_supported});
+    re->add_operation("exec_rule_expression", operation<const std::string&, msParamArray_t*, const std::string&, irods::callback>{not_supported});
 
     return re;
 }


### PR DESCRIPTION
Please review the install location for the new rule file that fixes the issues related to undefined PEPs and the REPF.