### PR TITLE
[irods/irods#4627] Bump externals to match 4-2-stable

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -8,16 +8,15 @@ import tempfile
 import irods_python_ci_utilities
 
 def install_cmake_and_add_to_front_of_path():
-    irods_python_ci_utilities.install_os_packages(['irods-externals-cmake3.5.2-0'])
-    os.environ['PATH'] = '/opt/irods-externals/cmake3.5.2-0/bin' + os.pathsep + os.environ['PATH']
+    irods_python_ci_utilities.install_os_packages(['irods-externals-cmake3.11.4-0'])
+    os.environ['PATH'] = '/opt/irods-externals/cmake3.11.4-0/bin' + os.pathsep + os.environ['PATH']
 
 def get_build_prerequisites_all():
-    return ['irods-externals-clang3.8-0',
-            'irods-externals-libarchive3.3.2-0',
-            'irods-externals-avro1.7.7-0',
-            'irods-externals-clang-runtime3.8-0',
-            'irods-externals-boost1.60.0-0',
-            'irods-externals-jansson2.7-0']
+    return ['irods-externals-avropre190cpp17-0',
+            'irods-externals-boost1.67.0-0',
+            'irods-externals-clang-runtime6.0-0',
+            'irods-externals-clang6.0-0',
+            'irods-externals-libarchive3.3.2-1']
 
 def get_build_prerequisites_apt():
     return ['make', 'gcc'] + get_build_prerequisites_all()


### PR DESCRIPTION
Needs irods/irods#4630 first. CI tests passed.