### PR TITLE
dependencies added to the build hook

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -18,7 +18,9 @@ def install_building_dependencies(externals_directory):
                       'irods-externals-boost1.67.0-0',
                       'irods-externals-clang-runtime6.0-0',
                       'irods-externals-clang6.0-0',
-                      'irods-externals-libarchive3.3.2-1']
+                      'irods-externals-fmt6.1.2-1',
+                      'irods-externals-libarchive3.3.2-1',
+                      'irods-externals-nanodbc2.13.0-0']
     if externals_directory == 'None' or externals_directory is None:
         irods_python_ci_utilities.install_irods_core_dev_repository()
         irods_python_ci_utilities.install_os_packages(externals_list)


### PR DESCRIPTION
these dependencies are needed for the iRODS dev and runtime packages